### PR TITLE
Fix compilation in python 3.11+

### DIFF
--- a/ssh2/agent.c
+++ b/ssh2/agent.c
@@ -5537,6 +5537,11 @@ bad:
     #endif
     return NULL;
 }
+
+#if PY_VERSION_HEX >= 0x030b00a6
+  #include "internal/pycore_frame.h"
+#endif
+
 static void __Pyx_AddTraceback(const char *funcname, int c_line,
                                int py_line, const char *filename) {
     PyCodeObject *py_code = 0;

--- a/ssh2/channel.c
+++ b/ssh2/channel.c
@@ -9328,6 +9328,11 @@ bad:
     #endif
     return NULL;
 }
+
+#if PY_VERSION_HEX >= 0x030b00a6
+  #include "internal/pycore_frame.h"
+#endif
+
 static void __Pyx_AddTraceback(const char *funcname, int c_line,
                                int py_line, const char *filename) {
     PyCodeObject *py_code = 0;

--- a/ssh2/error_codes.c
+++ b/ssh2/error_codes.c
@@ -2521,6 +2521,10 @@ bad:
     #endif
     return NULL;
 }
+#if PY_VERSION_HEX >= 0x030b00a6
+  #include "internal/pycore_frame.h"
+#endif
+
 static void __Pyx_AddTraceback(const char *funcname, int c_line,
                                int py_line, const char *filename) {
     PyCodeObject *py_code = 0;

--- a/ssh2/exceptions.c
+++ b/ssh2/exceptions.c
@@ -4284,6 +4284,10 @@ bad:
     #endif
     return NULL;
 }
+#if PY_VERSION_HEX >= 0x030b00a6
+  #include "internal/pycore_frame.h"
+#endif
+
 static void __Pyx_AddTraceback(const char *funcname, int c_line,
                                int py_line, const char *filename) {
     PyCodeObject *py_code = 0;

--- a/ssh2/fileinfo.c
+++ b/ssh2/fileinfo.c
@@ -3649,6 +3649,11 @@ bad:
     #endif
     return NULL;
 }
+
+#if PY_VERSION_HEX >= 0x030b00a6
+  #include "internal/pycore_frame.h"
+#endif
+
 static void __Pyx_AddTraceback(const char *funcname, int c_line,
                                int py_line, const char *filename) {
     PyCodeObject *py_code = 0;

--- a/ssh2/knownhost.c
+++ b/ssh2/knownhost.c
@@ -8481,6 +8481,11 @@ bad:
     #endif
     return NULL;
 }
+
+#if PY_VERSION_HEX >= 0x030b00a6
+  #include "internal/pycore_frame.h"
+#endif
+
 static void __Pyx_AddTraceback(const char *funcname, int c_line,
                                int py_line, const char *filename) {
     PyCodeObject *py_code = 0;

--- a/ssh2/libssh2_enums.c
+++ b/ssh2/libssh2_enums.c
@@ -4284,6 +4284,11 @@ bad:
     #endif
     return NULL;
 }
+
+#if PY_VERSION_HEX >= 0x030b00a6
+  #include "internal/pycore_frame.h"
+#endif
+
 static void __Pyx_AddTraceback(const char *funcname, int c_line,
                                int py_line, const char *filename) {
     PyCodeObject *py_code = 0;

--- a/ssh2/listener.c
+++ b/ssh2/listener.c
@@ -3362,6 +3362,11 @@ bad:
     #endif
     return NULL;
 }
+
+#if PY_VERSION_HEX >= 0x030b00a6
+  #include "internal/pycore_frame.h"
+#endif
+
 static void __Pyx_AddTraceback(const char *funcname, int c_line,
                                int py_line, const char *filename) {
     PyCodeObject *py_code = 0;

--- a/ssh2/pkey.c
+++ b/ssh2/pkey.c
@@ -3088,6 +3088,11 @@ bad:
     #endif
     return NULL;
 }
+
+#if PY_VERSION_HEX >= 0x030b00a6
+  #include "internal/pycore_frame.h"
+#endif
+
 static void __Pyx_AddTraceback(const char *funcname, int c_line,
                                int py_line, const char *filename) {
     PyCodeObject *py_code = 0;

--- a/ssh2/publickey.c
+++ b/ssh2/publickey.c
@@ -7176,6 +7176,11 @@ bad:
     #endif
     return NULL;
 }
+
+#if PY_VERSION_HEX >= 0x030b00a6
+  #include "internal/pycore_frame.h"
+#endif
+
 static void __Pyx_AddTraceback(const char *funcname, int c_line,
                                int py_line, const char *filename) {
     PyCodeObject *py_code = 0;

--- a/ssh2/session.c
+++ b/ssh2/session.c
@@ -16495,6 +16495,11 @@ bad:
     #endif
     return NULL;
 }
+
+#if PY_VERSION_HEX >= 0x030b00a6
+  #include "internal/pycore_frame.h"
+#endif
+
 static void __Pyx_AddTraceback(const char *funcname, int c_line,
                                int py_line, const char *filename) {
     PyCodeObject *py_code = 0;

--- a/ssh2/sftp.c
+++ b/ssh2/sftp.c
@@ -7589,6 +7589,11 @@ bad:
     #endif
     return NULL;
 }
+
+#if PY_VERSION_HEX >= 0x030b00a6
+  #include "internal/pycore_frame.h"
+#endif
+
 static void __Pyx_AddTraceback(const char *funcname, int c_line,
                                int py_line, const char *filename) {
     PyCodeObject *py_code = 0;

--- a/ssh2/sftp_handle.c
+++ b/ssh2/sftp_handle.c
@@ -11656,6 +11656,11 @@ bad:
     #endif
     return NULL;
 }
+
+#if PY_VERSION_HEX >= 0x030b00a6
+  #include "internal/pycore_frame.h"
+#endif
+
 static void __Pyx_AddTraceback(const char *funcname, int c_line,
                                int py_line, const char *filename) {
     PyCodeObject *py_code = 0;
@@ -13298,6 +13303,11 @@ PyObject *__Pyx_Coroutine_SendEx(__pyx_CoroutineObject *self, PyObject *value, i
 #endif
     return retval;
 }
+
+#if PY_VERSION_HEX >= 0x030b00a6
+    #include "internal/pycore_frame.h"
+#endif
+
 static CYTHON_INLINE void __Pyx_Coroutine_ResetFrameBackpointer(__Pyx_ExcInfoStruct *exc_state) {
     PyObject *exc_tb = exc_state->exc_traceback;
     if (likely(exc_tb)) {

--- a/ssh2/statinfo.c
+++ b/ssh2/statinfo.c
@@ -3672,6 +3672,11 @@ bad:
     #endif
     return NULL;
 }
+
+#if PY_VERSION_HEX >= 0x030b00a6
+  #include "internal/pycore_frame.h"
+#endif
+
 static void __Pyx_AddTraceback(const char *funcname, int c_line,
                                int py_line, const char *filename) {
     PyCodeObject *py_code = 0;

--- a/ssh2/tunnel.c
+++ b/ssh2/tunnel.c
@@ -5890,6 +5890,11 @@ bad:
     #endif
     return NULL;
 }
+
+#if PY_VERSION_HEX >= 0x030b00a6
+  #include "internal/pycore_frame.h"
+#endif
+
 static void __Pyx_AddTraceback(const char *funcname, int c_line,
                                int py_line, const char *filename) {
     PyCodeObject *py_code = 0;

--- a/ssh2/utils.c
+++ b/ssh2/utils.c
@@ -5557,6 +5557,11 @@ bad:
     #endif
     return NULL;
 }
+
+#if PY_VERSION_HEX >= 0x030b00a6
+  #include "internal/pycore_frame.h"
+#endif
+
 static void __Pyx_AddTraceback(const char *funcname, int c_line,
                                int py_line, const char *filename) {
     PyCodeObject *py_code = 0;


### PR DESCRIPTION
Compiling in Fedora 37 w/ python 3.11.0:

      gcc -Wsign-compare -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -O2 -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -fPIC -Ilibssh2/include -I/usr/include/python3.11 -c ssh2/utils.c -o build/temp.linux-x86_64-cpython-311/ssh2/utils.o -O3
      ssh2/utils.c: In function ‘__Pyx_AddTraceback’:
      ssh2/utils.c:438:62: error: invalid use of incomplete typedef ‘PyFrameObject
  {aka ‘struct _frame’}
        438 |   #define __Pyx_PyFrame_SetLineNumber(frame, lineno)  (frame)->f_lineno = (lineno)
            |                                                              ^~
      ssh2/utils.c:5582:5: note: in expansion of macro ‘__Pyx_PyFrame_SetLineNumber’
       5582 |     __Pyx_PyFrame_SetLineNumber(py_frame, py_line);
            |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
      error: command '/usr/bin/gcc' failed with exit code 1

Fix is nalogous to https://github.com/cython/cython/commit/afc00fc3ba5d43c67151c0039847a526e7b627a5